### PR TITLE
Active Model Serializers 0.9 Support

### DIFF
--- a/lib/tire/am_serializers.rb
+++ b/lib/tire/am_serializers.rb
@@ -1,6 +1,10 @@
 require "tire/version"
 require "tire/active_model/serializer_support"
 
-Tire::Results::Collection.send(:include, ActiveModel::ArraySerializerSupport)
+if defined?(ActiveModel::Serializable)
+  Tire::Results::Collection.send(:include, ActiveModel::Serializable)
+else
+  Tire::Results::Collection.send(:include, ActiveModel::ArraySerializerSupport)
+end
 Tire::Results::Item.send(:include, ActiveModel::SerializerSupport)
 Tire::Results::Item.send(:include, Tire::ActiveModel::SerializerSupport)


### PR DESCRIPTION
`ActiveModel::Serializable` replaces `ActiveModel::ArraySerializerSupport` in 0.9, https://github.com/rails-api/active_model_serializers/blob/0-9-stable/lib/active_model/serializable.rb.
